### PR TITLE
Step3:APIから値を取得する

### DIFF
--- a/spec/agreed/agreed.ts
+++ b/spec/agreed/agreed.ts
@@ -5,5 +5,6 @@ module.exports = convert(
   ...flatten([
     require("./agreedsample/get"),
     require("./uploadsample/post"),
+    require("./hello/getComments"),
   ]),
 );

--- a/spec/agreed/hello/getComments.ts
+++ b/spec/agreed/hello/getComments.ts
@@ -1,0 +1,38 @@
+import { APIDef, GET, Success200, ResponseDef, Error404 } from "agreed-typed";
+
+export type HelloGetAPI = APIDef<
+  GET, // HTTP Method
+  ["hello"],
+  {}, // request header
+  {}, // request query
+  undefined, // request body
+  {}, // response header
+  ResponseDef<Success200, { results: { comments: {id: string, text: string }[] } }>
+>;
+
+const api: HelloGetAPI = {
+  request: {
+    path: ["hello"],
+    method: "GET",
+    body: undefined,
+  },
+  response: {
+    status: 200,
+    body: {
+      results: {
+        comments: [
+          {
+            id: "0001",
+            text: "Hello",
+          },
+          {
+            id: "0002",
+            text: "world",
+          },
+        ],
+      },
+    },
+  },
+};
+
+module.exports = api;

--- a/src/server/services/Hello.ts
+++ b/src/server/services/Hello.ts
@@ -1,0 +1,19 @@
+import Axios from "axios";
+import { read } from "./utils"; // axios を使い get request を投げる util
+
+export default class Hello {
+  name: string;
+  axios: any;
+  pathname: string;
+
+  constructor(config: any) {
+    this.name = "hello"; // hello と言う名前をつける
+    // server の設定ファイル (src/server/configs) の中から agreed 向けの axios を設定
+    this.axios = Axios.create(config.agreed.config.axios);
+    this.pathname = "hello";
+  }
+
+  read(req: any, resource: any, params: any = {}, config: any) {
+    return read(this.axios, this.name, this.pathname, params, {});
+  }
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -2,3 +2,4 @@ export { default as AccessToken } from "./AccessToken";
 export { default as AgreedSample } from "./AgreedSample";
 export { default as Counter } from "./Counter";
 export { default as HackerNews } from "./HackerNews";
+export { default as Hello } from "./Hello";

--- a/src/shared/components/organisms/Hello/Hello.tsx
+++ b/src/shared/components/organisms/Hello/Hello.tsx
@@ -3,14 +3,23 @@ import React from "react";
 type Props = {
   // props の型定義
   isVisible: boolean;
+  comments: {
+    id: string;
+    text: string;
+  }[];
   onChangeVisibility: Function;
+  onClickGetComments: Function;
 };
 
 export default function Hello(props: Props) {
-  const { isVisible, onChangeVisibility } = props;
+  const { isVisible, onChangeVisibility, comments, onClickGetComments } = props;
   return (
     <div>
-      {isVisible && <div>Hello!</div>}
+      {isVisible &&
+        comments.map(comment => <div key={comment.id}>{comment.text}</div>)}
+      <button type="button" onClick={() => onClickGetComments()}>
+        get comments
+      </button>
       <button type="button" onClick={() => onChangeVisibility()}>
         {isVisible ? "hide" : "show"}
       </button>

--- a/src/shared/components/organisms/Hello/index.tsx
+++ b/src/shared/components/organisms/Hello/index.tsx
@@ -1,6 +1,6 @@
 import { compose } from "redux";
 import { connect } from "react-redux";
-import { changeVisibility } from "../../../redux/modules/hello";
+import { changeVisibility, getComments } from "../../../redux/modules/hello";
 import { RootState } from "../../../redux/modules/reducer";
 import Hello from "./Hello";
 
@@ -8,9 +8,11 @@ export default compose(
   connect(
     (state: RootState) => ({
       isVisible: state.app.hello.isVisible, // store の state の中から、指定した isVisible を props として渡す
+      comments: state.app.hello.comments,
     }),
     dispatch => ({
       onChangeVisibility: () => dispatch(changeVisibility()), // changeVisibilityを store に　dispatchする関数を返す
+      onClickGetComments: () => dispatch(getComments() as any),
     }),
   ),
 )(Hello);

--- a/src/shared/redux/modules/hello.ts
+++ b/src/shared/redux/modules/hello.ts
@@ -1,13 +1,37 @@
+import { steps } from "redux-effects-steps";
+import { fetchrRead } from "redux-effects-fetchr";
+
 /**
  * Action types
  */
 const HELLO_CHANGE_VISIBILITY = "redux-pluto/hello/visibility/change"; // 表示・非表示を切り替える Action の type
+const HELLO_GET_COMMENTS_REQUEST = "redux-pluto/hello/get/comments/request";
+const HELLO_GET_COMMENTS_SUCCESS = "redux-pluto/hello/get/comments/success";
+const HELLO_GET_COMMENTS_FAIL = "redux-pluto/hello/get/comments/fail";
 
 type ChangeVisibility = {
   type: typeof HELLO_CHANGE_VISIBILITY;
 };
+type CommentsRequest = {
+  type: typeof HELLO_GET_COMMENTS_REQUEST;
+  payload: {
+    resource: string;
+  };
+};
+type CommentsSuccess = {
+  type: typeof HELLO_GET_COMMENTS_SUCCESS;
+  payload: any;
+};
+type CommentsFail = {
+  type: typeof HELLO_GET_COMMENTS_FAIL;
+  error: boolean;
+};
 
-type Action = ChangeVisibility;
+type Action =
+  | ChangeVisibility
+  | CommentsRequest
+  | CommentsSuccess
+  | CommentsFail;
 
 /**
  * Action creators
@@ -18,17 +42,55 @@ export function changeVisibility() {
   };
 }
 
+export function getCommentsRequest(payload: {
+  resource: string;
+}): CommentsRequest {
+  return {
+    type: HELLO_GET_COMMENTS_REQUEST,
+    payload,
+  };
+}
+
+export function getCommentsSuccess(res: any) {
+  return {
+    type: HELLO_GET_COMMENTS_SUCCESS,
+    payload: res,
+  };
+}
+
+export function getCommentsFail() {
+  return {
+    type: HELLO_GET_COMMENTS_FAIL,
+    error: true,
+  };
+}
+
+export function getComments() {
+  return steps(
+    getCommentsRequest({ resource: "hello" }),
+    ({ payload }) => fetchrRead(payload),
+    [getCommentsSuccess, getCommentsFail],
+  );
+}
+
 /**
  * Initial state
  */
 // module 内で管理する state の型
 export type State = {
   isVisible: boolean;
+  comments: { id: string; text: string }[];
+  loading: boolean;
+  loaded: boolean;
+  error?: boolean;
 };
 
 // store に展開される初期値
 const INITIAL_STATE = {
   isVisible: true,
+  comments: [],
+  loading: true,
+  loaded: false,
 };
 
 /**
@@ -40,6 +102,35 @@ export default function(state: State = INITIAL_STATE, action: Action): State {
       return {
         ...state,
         isVisible: !state.isVisible,
+      };
+    }
+    case HELLO_GET_COMMENTS_REQUEST: {
+      return {
+        ...state,
+        loading: true,
+        loaded: false,
+      };
+    }
+    case HELLO_GET_COMMENTS_SUCCESS: {
+      const {
+        payload: {
+          data: { comments },
+        },
+      } = action;
+      return {
+        ...state,
+        comments,
+        loading: false,
+        loaded: true,
+      };
+    }
+    case HELLO_GET_COMMENTS_FAIL: {
+      const { error } = action;
+      return {
+        ...state,
+        error,
+        loading: false,
+        loaded: false,
       };
     }
     default: {


### PR DESCRIPTION
# APIを用意する
## 感想
とりまのコピペ。
わからんことが多すぎると、いっぺんコピペしてみよう、という気になる。

## つまづき


## 気になり
> ここでは API 通信の中間点となるMicroservice Architecture の service に当たるものを作成していきます。

そうか、、、（まだ、そんなもんね程度）

> redux-pluto では BFF(Backends for Frontends) というフロントエンド用のサーバーが立っています。
> ブラウザ → BFF 間の通信は fetchr 
> BFF → APIサーバ 間の通信は axios

Fetchr用にいろいろチクチク設定して、expressのmiddlewareに突っ込んでおり、これがBFFとして機能してる、、んだよね？（逆かな、BFF用にFetchrを用いてmiddlewareの設定をする）
※ webpack entry で entryにserver/index.tsが設定されていて、webpackはbin/start-serverから呼び出されている？
※ agreedは別（agreed-server script）かしら、、、

逆にNext.jsがファイルシステムで作れるよう隠蔽していてすごいなと感じたけど、どんな塩梅なんじゃろ。（Fetchrに関して）


# ページを開くタイミングでAPIにリクエストを飛ばす